### PR TITLE
add support for download-then-play use scenario

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,6 +9,10 @@ var contextMenu = require("sdk/context-menu");
 var querystring = require("sdk/querystring");
 
 function play_video(url) {
+	
+	if(simple_prefs.prefs.downloadThenPlay)
+		return download_then_play(url);
+	
 	var file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
 	file.initWithPath(simple_prefs.prefs.player);
 
@@ -54,6 +58,55 @@ function play_video(url) {
       };
     };
   };
+
+	args.push(url);
+
+	// process.run(false, args, args.length);
+	process.runAsync(args, args.length);
+}
+
+function download_then_play(url){
+	
+	var file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
+	file.initWithPath(simple_prefs.prefs.ytdlBinary);
+
+	// create an nsIProcess
+	var process = Cc["@mozilla.org/process/util;1"].createInstance(Ci.nsIProcess);
+	process.init(file);
+
+	var params = simple_prefs.prefs.params;
+
+	if (params)
+	    var args = params.split(" ");
+    else
+        var args = [];
+	
+	// specify file name
+	if(args.indexOf('--output') == -1){
+		args.push('--output');	
+		args.push(simple_prefs.prefs.downloadDirectory + '%(id)s.%(height)s.%(ext)s');
+	}
+	
+	// @youtube-dl bug single quote exec
+	var xulRuntime = Cc["@mozilla.org/xre/app-info;1"]
+                 .getService(Ci.nsIXULRuntime);
+	
+	// hook mpv into ytdl's postprocess trigger 
+	if(args.indexOf('--exec') == -1){
+		
+		args.push('--exec');
+		// the file itself is added automatically
+		//  see: https://github.com/rg3/youtube-dl/blob/1b6712ab2378b2e8eb59f372fb51193f8d3bdc97/youtube_dl/postprocessor/execafterdownload.py#L17		
+		
+		// Bug in youtube-dl: uses single quotes
+		// see https://github.com/rg3/youtube-dl/issues/11497
+		// so we'll try to use powershell for that
+		if(xulRuntime.OS.indexOf('WINNT') != -1){
+			args.push('powershell -Command "& \'' + simple_prefs.prefs.player + '\' {}"');
+		} else {		
+			args.push(simple_prefs.prefs.player);
+		}
+	}
 
 	args.push(url);
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -70,11 +70,10 @@ function download_then_play(url){
 	var file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
 	file.initWithPath(simple_prefs.prefs.ytdlBinary);
 
-	// create an nsIProcess
 	var process = Cc["@mozilla.org/process/util;1"].createInstance(Ci.nsIProcess);
 	process.init(file);
 
-	var params = simple_prefs.prefs.params;
+	var params = simple_prefs.prefs.ytdlParams;
 
 	if (params)
 	    var args = params.split(" ");
@@ -87,22 +86,20 @@ function download_then_play(url){
 		args.push(simple_prefs.prefs.downloadDirectory + '%(id)s.%(height)s.%(ext)s');
 	}
 	
-	// @youtube-dl bug single quote exec
-	var xulRuntime = Cc["@mozilla.org/xre/app-info;1"]
-                 .getService(Ci.nsIXULRuntime);
-	
 	// hook mpv into ytdl's postprocess trigger 
 	if(args.indexOf('--exec') == -1){
 		
 		args.push('--exec');
-		// the file itself is added automatically
+		// the file itself is added automatically by youtube-dl
 		//  see: https://github.com/rg3/youtube-dl/blob/1b6712ab2378b2e8eb59f372fb51193f8d3bdc97/youtube_dl/postprocessor/execafterdownload.py#L17		
 		
 		// Bug in youtube-dl: uses single quotes
-		// see https://github.com/rg3/youtube-dl/issues/11497
+		// see https://github.com/rg3/youtube-dl/issues/5889
 		// so we'll try to use powershell for that
+		var xulRuntime = Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime);
+		
 		if(xulRuntime.OS.indexOf('WINNT') != -1){
-			args.push('powershell -Command "& \'' + simple_prefs.prefs.player + '\' {}"');
+			args.push('powershell -Command "Start-Process \'' + simple_prefs.prefs.player + '\' {}"');
 		} else {		
 			args.push(simple_prefs.prefs.player);
 		}
@@ -110,8 +107,27 @@ function download_then_play(url){
 
 	args.push(url);
 
-	// process.run(false, args, args.length);
-	process.runAsync(args, args.length);
+	// Set badge text / notification counter
+	action_button.badge = action_button.badge ? +action_button.badge +1 : 1;
+	action_button.label = 'Running downloads: ' + action_button.badge + '\n\nPlay tab with MPV';
+	
+	process.runAsync(args, args.length, {
+		
+		observe: function(subject, topic, data){
+			
+			// insures that
+			// - no negative number of downloads is displayed
+			// - the number is also removed when the last running download finishes
+			action_button.badge = action_button.badge > 1 ? +action_button.badge -1 : '';
+			if(action_button.badge){
+				action_button.label = 'Running downloads: ' + action_button.badge + '\n\nPlay tab with MPV';
+			}
+			else {
+				action_button.label = 'Play tab with MPV';
+			}
+		}
+		
+	});
 }
 
 var menuItem = contextMenu.Item({
@@ -127,7 +143,7 @@ var menuItem = contextMenu.Item({
 
 var action_button = ui.ActionButton({
   id: "my-button",
-  label: "Play with MPV",
+  label: "Play tab with MPV",
   icon: data.url("icon_button.png"),
   onClick: function(state) {
     play_video(tabs.activeTab.url);

--- a/package.json
+++ b/package.json
@@ -19,13 +19,6 @@
             "type": "string",
             "value": "/usr/bin/mpv"
         },
-		{
-            "name": "ytdlBinary",
-            "title": "youtube-dl location",
-            "description": "Specify youtube-dl full path if not in PATH",
-            "type": "string",
-            "value": "youtube-dl"
-        },
         {
             "name": "hotkey",
             "title": "Hotkey",
@@ -57,13 +50,27 @@
 		{
             "name": "downloadThenPlay",
             "title": "Download before playing",
-            "description": "Download with youtube-dl before playing. Do not use youtube-dl's -o option.\nWindows: Requires Powershell to auto-play after download",
+            "description": "Download the video with youtube-dl before playing it with the specified media player.\nWindows: Requires Powershell to auto-play after download",
             "type": "bool",
-            "value": true
+            "value": false
+        },
+		{
+            "name": "ytdlBinary",
+            "title": "youtube-dl location",
+            "description": "Specify youtube-dl full path. \nOnly required if 'Download before playing' is active",
+            "type": "string",
+            "value": "youtube-dl"
+        },
+		{
+            "name": "ytdlParams",
+            "title": "youtube-dl parameters",
+            "description": "Specify parameters passed to youtube-dl. Parameters --output and --exec are automatically added if not specified here.\nOnly used if 'Download before playing' is active",
+            "type": "string",
+            "value": ""
         },
 		{
             "name": "downloadDirectory",
-            "title": "Download into this directory",
+            "title": "Download directory",
             "description": "If 'Download before playing' is active, files will be downloaded into this directory.",
             "type": "string",
             "value": "/tmp/"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,13 @@
             "type": "string",
             "value": "/usr/bin/mpv"
         },
+		{
+            "name": "ytdlBinary",
+            "title": "youtube-dl location",
+            "description": "Specify youtube-dl full path if not in PATH",
+            "type": "string",
+            "value": "youtube-dl"
+        },
         {
             "name": "hotkey",
             "title": "Hotkey",
@@ -47,5 +54,19 @@
             "type": "bool",
             "value": false
         },
+		{
+            "name": "downloadThenPlay",
+            "title": "Download before playing",
+            "description": "Download with youtube-dl before playing. Do not use youtube-dl's -o option.\nWindows: Requires Powershell to auto-play after download",
+            "type": "bool",
+            "value": true
+        },
+		{
+            "name": "downloadDirectory",
+            "title": "Download into this directory",
+            "description": "If 'Download before playing' is active, files will be downloaded into this directory.",
+            "type": "string",
+            "value": "/tmp/"
+        }
     ]
 }


### PR DESCRIPTION
This PR adds support for downloading videos completely before playing them, as requested in issues #28 and #32.
Three settings are added:
- Download before playing (the switch for the feature itself)
- Path to youtube-dl
- parameters for youtube-dl **(added)**
- target directory

Tests on Ubuntu 16.04 and Windows 2012 R2 indicate no problems.

Limitations:
- auto-play does not work with playlists (would require to generate a playlist file or be specific to some media players)
- requires workaround on windows due to [youtube-dl#Issue 5889](https://github.com/rg3/youtube-dl/issues/5889), currently by using powershell (Windows 7+)
- ~~after opening a link with the addon, there is no indication whether youtube-dl is currently downloading or the configuration is bad~~ **(fixed)**
- ~~when enabled, the parameters are used for youtube-dl, not for the player~~ **(fixed)**

**Improvements 2017-02-19**
- when one oder multiple downloads are running, a counter is displayed on top of the mpv icon in the toolbar (if the icon is visible) indicating the number of running downloads. The hover text is updated similarly
- youtube-dl has now it's own parameter setting. As documented in the description, parameters for youtube-dl are **only** for downloading, not for streaming.
(Reasoning: Users can enable/disable downloading without having to modify the `--ytdl-raw-options` parameter of the player, if used)
- player parameters are **not** used when downloading is enabled - This is in line with the previous point to insure that users can switch between 'streaming' and 'downloading' without having to modify parameters. Player parameters can still be set by specifying an `--exec` option.