### PR TITLE
Support YouTube URLs with start time

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -23,15 +23,19 @@ function play_video(url) {
     else
         var args = [];
 
+  // Checks if running on Youtube
+  if (url.indexOf("youtube.com") > -1) { // url is Youtube link
 
-  if (simple_prefs.prefs.ytStartPlAtIndex) {
+    // Parses url params to an object returning object like:
+    // {"v":"g04s2u30NfQ","index":"3","list":"PL58H4uS5fMRzmMC_SfMelnCoHgB8COa5r"}
+    var qs = querystring.parse(url.split("?")[1]);
 
-    // Checks if running on Youtube
-    if (url.indexOf("youtube.com") > -1) { // url is Youtube link
+    if (parseInt(qs["t"]) > 0) {
+      // jump to start time
+      args.concat(["--start", qs["t"]]);
+    }
 
-      // Parses url params to an object returning object like:
-      // {"v":"g04s2u30NfQ","index":"3","list":"PL58H4uS5fMRzmMC_SfMelnCoHgB8COa5r"}
-      var qs = querystring.parse(url.split("?")[1]);
+    if (simple_prefs.prefs.ytStartPlAtIndex) {
 
       if (qs["list"] && qs["index"]) { // we have the playlist and the video index
 


### PR DESCRIPTION
This adds support for YouTube URLs with start time ([example](https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=18)), and adds `--start xxx` to the mpv command line to jump to the appropriate part of the video.

Tested with Firefox 54 developer edition.